### PR TITLE
Added a backup.skip-not-found option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Options:
         The target path to the backup folder. (default "backup")
   -config.file string
         The path to your config file. (default "git-backup.yml")
+  -backup.fail-at-end
+      Fail at the end of backing up repositories, rather than right away.
 ```
 
 ## Usage: Docker


### PR DESCRIPTION
When testing this, it turned out I had a couple of repositories starred that got removed (but were still getting returned by Github their API). With this option I can just skip over those repositories, rather than stop and not back up any other pending repositories. I put the default on false to retain original behavior, although in my opinion having this on by default would be more useful.