### PR TITLE
Added a backup.bare-clone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Options:
         The path to your config file. (default "git-backup.yml")
   -backup.fail-at-end
       Fail at the end of backing up repositories, rather than right away.
+  -backup.bare-clone
+        Make bare clones without checking out the main branch.
 ```
 
 ## Usage: Docker

--- a/cmd/git-backup/main.go
+++ b/cmd/git-backup/main.go
@@ -12,6 +12,7 @@ import (
 var configFilePath = flag.String("config.file", "git-backup.yml", "The path to your config file.")
 var targetPath = flag.String("backup.path", "backup", "The target path to the backup folder.")
 var failAtEnd = flag.Bool("backup.fail-at-end", false, "Fail at the end of backing up repositories, rather than right away.")
+var bareClone = flag.Bool("backup.bare-clone", false, "Make bare clones without checking out the main branch.")
 
 func main() {
 	flag.Parse()
@@ -45,7 +46,7 @@ func main() {
 				log.Printf("Failed to create directory: %s", err)
 				os.Exit(100)
 			}
-			err = repo.CloneInto(targetPath)
+			err = repo.CloneInto(targetPath, *bareClone)
 			if err != nil {
 				errors++
 				log.Printf("Failed to clone: %s", err)

--- a/repository.go
+++ b/repository.go
@@ -1,12 +1,13 @@
 package git_backup
 
 import (
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"log"
 	"net/url"
 	"os"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 type RepositorySource interface {
@@ -20,7 +21,7 @@ type Repository struct {
 	FullName string
 }
 
-func (r *Repository) CloneInto(path string) error {
+func (r *Repository) CloneInto(path string, bare bool) error {
 	var auth http.AuthMethod
 	if r.GitURL.User != nil {
 		password, _ := r.GitURL.User.Password()
@@ -29,7 +30,7 @@ func (r *Repository) CloneInto(path string) error {
 			Password: password,
 		}
 	}
-	gitRepo, err := git.PlainClone(path, false, &git.CloneOptions{
+	gitRepo, err := git.PlainClone(path, bare, &git.CloneOptions{
 		URL:      r.GitURL.String(),
 		Auth:     auth,
 		Progress: os.Stdout,


### PR DESCRIPTION
As mentioned yesterday. I implemented a backup.bare-clone flag which will make it do bare clones instead. Checking out a branch isn't really needed when making backups in my opinion. Doing bare clones would even save some disk space.