### PR TITLE
Add option to exclude repositories.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.8'
+          go-version: '^1.18.10'
       - run: ${{ matrix.goopts }} go build -o ${{ matrix.filename }} -ldflags="-X 'main.Version=${GITHUB_REF##*/}' -X 'main.CommitHash=${GITHUB_SHA}' -X 'main.BuildTimestamp=$(date)'" ./cmd/git-backup
         env:
           GOOS: ${{ matrix.goos }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ github:
     # your self-hosted github install.
     # (default: https://api.github.com)
     url: https://github.mydomain.com
+    # (optional) Exclude this list of repos
+    excluded:
+      - my-namespace/excluded-repository-name
 # The gitlab section contains backup jobs for
 # GitLab.com and GitLab on premise
 gitlab:
@@ -64,6 +67,9 @@ gitlab:
     # your self-hosted gitlab install.
     # (default: https://gitlab.com/)
     url: https://gitlab.mydomain.com
+    # (optional) Exclude this list of repos
+    excluded:
+      - my-namespace/excluded-repository-name
 ```
 
 ## Usage: CLI

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module git-backup
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-git/go-git/v5 v5.4.2


### PR DESCRIPTION
I have some starred GitHub repositories that are multiple gigabytes in size. I prefer to skip those, so I've added a configuration option for both GitHub and GitLab to skip repositories based on their path (e.g. `ChappIO/git-backup`).

Filtering via `slices.ContainsFunc` required Go >= 1.18, so I've bumped that version requirement.