### PR TITLE
Exclude WIldcard & Fix of Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ github:
     # (default: https://api.github.com)
     url: https://github.mydomain.com
     # (optional) Exclude this list of repos
+    # or whole organizations/users
     exclude:
+      - my-excluded-org
+      - my-excluded-user
       - my-namespace/excluded-repository-name
 # The gitlab section contains backup jobs for
 # GitLab.com and GitLab on premise

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ gitlab:
     # (default: https://gitlab.com/)
     url: https://gitlab.mydomain.com
     # (optional) Exclude this list of repos
+    # or whole organizations/users
     exclude:
+      - my-excluded-org
+      - my-excluded-user
       - my-namespace/excluded-repository-name
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ github:
     # (default: https://api.github.com)
     url: https://github.mydomain.com
     # (optional) Exclude this list of repos
-    excluded:
+    exclude:
       - my-namespace/excluded-repository-name
 # The gitlab section contains backup jobs for
 # GitLab.com and GitLab on premise
@@ -68,7 +68,7 @@ gitlab:
     # (default: https://gitlab.com/)
     url: https://gitlab.mydomain.com
     # (optional) Exclude this list of repos
-    excluded:
+    exclude:
       - my-namespace/excluded-repository-name
 ```
 

--- a/github.go
+++ b/github.go
@@ -51,7 +51,16 @@ func (c *GithubConfig) ListRepositories() ([]*Repository, error) {
 		gitUrl.User = url.UserPassword("github", c.AccessToken)
 
 		isExcluded := slices.ContainsFunc(c.Exclude, func(s string) bool {
-			return strings.EqualFold(s, *repo.FullName)
+			if strings.EqualFold(s, *repo.FullName) {
+				return true
+			}
+
+			if strings.Contains(s, "/") {
+				return false
+			}
+
+			repoOwner = *repo.FullName[:strings.Index(*repo.FullName, "/")]
+			return strings.EqualFold(s, repoOwner)
 		})
 		if isExcluded {
 			log.Printf("Skipping excluded repository: %s", *repo.FullName)

--- a/github.go
+++ b/github.go
@@ -59,7 +59,9 @@ func (c *GithubConfig) ListRepositories() ([]*Repository, error) {
 				return false
 			}
 
-			repoOwner = *repo.FullName[:strings.Index(*repo.FullName, "/")]
+			repoFullName := *repo.FullName
+
+			repoOwner := repoFullName[:strings.Index(repoFullName, "/")]
 			return strings.EqualFold(s, repoOwner)
 		})
 		if isExcluded {

--- a/gitlab.go
+++ b/gitlab.go
@@ -69,7 +69,18 @@ func (g *GitLabConfig) ListRepositories() ([]*Repository, error) {
 	outSlice := make([]*Repository, 0, len(out))
 	for _, repository := range out {
 		isExcluded := slices.ContainsFunc(g.Exclude, func(s string) bool {
-			return strings.EqualFold(s, repository.FullName)
+			if strings.EqualFold(s, repository.FullName) {
+				return true
+			}
+
+			if strings.Contains(s, "/") {
+				return false
+			}
+
+			repoFullName := repository.FullName
+
+			repoOwner := repoFullName[:strings.Index(repoFullName, "/")]
+			return strings.EqualFold(s, repoOwner)
 		})
 		if isExcluded {
 			log.Printf("Skipping excluded repository: %s", repository.FullName)


### PR DESCRIPTION
## Info
- Fixes the documentation using `exclude` rather than `excluded` to match the word in code. Fixes #29 
- Improves usage of `exclude` to also be able to exclude whole organizations or users form backups